### PR TITLE
Replace Mailchimp form with Buttondown

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -68,12 +68,14 @@
                     We promise, we won't overload your inbox.
                 </p>
                 <form
-                    action="//pycascades.us15.list-manage.com/subscribe/post?u=910a586d174a45ddb1125ad4e&amp;id=1f87464654"
-                    method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank"
-                    class="">
+                    action="https://buttondown.com/api/emails/embed-subscribe/pycascades"
+                    method="post"
+                    target="popupwindow"
+                    onsubmit="window.open('https://newsletter.pycascades.com', 'popupwindow')"
+                    class="embeddable-buttondown-form">
                     <div class="field has-addons">
                         <div class="control is-expanded">
-                            <input class="input" type="email" name="EMAIL" value="" placeholder="Your Email"
+                            <input class="input" id="bd-email" type="email" name="email" value="" placeholder="Your Email"
                                 required="required">
                         </div>
                         <div class="control">
@@ -81,11 +83,6 @@
                                 Subscribe
                             </button>
                         </div>
-                    </div>
-
-
-                    <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                        <input type="text" name="b_910a586d174a45ddb1125ad4e_1f87464654" tabindex="-1" value="">
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
This replaces our Mailchimp form with our new Buttondown one! I've tested this with an email and was able to successfully subscribe :tada:
