### PR TITLE
Fix sponsorship email address

### DIFF
--- a/content/sponsors/become-a-sponsor/contents.lr
+++ b/content/sponsors/become-a-sponsor/contents.lr
@@ -13,7 +13,7 @@ no
 ### About The Conference
 PyCascades was started in 2018 as a regional PyCon for the Cascades Region, celebrating the west coast Python developer and user community. Our organizing team includes members of the Vancouver, Seattle, and Portland Python user groups.
 ### Getting in touch with us
-You can reach us via email at sponsorships@pycascades.com
+You can reach us via email at sponsorship@pycascades.com
 ### Sponsorship Tiers
 See the table on the following page for core tiers and benefits, then look below for add-ons to help set your organization apart.
 
@@ -37,7 +37,7 @@ title: Getting in touch with us
 ----
 hidden: False
 ----
-body: You can reach us via email at sponsorships@pycascades.com
+body: You can reach us via email at sponsorship@pycascades.com
 #### html ####
 hidden: False
 ----


### PR DESCRIPTION
Looks like we had accidentally added an `s` to the end of the sponsorship email on our website, I've confirmed that `sponsorship` should be the correct one.
