### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners for automatic reviews
+*   @bengerman13 @gelbelle @cache-rules @aetherunbound


### PR DESCRIPTION
This PR adds a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) which will allow reviewers for PRs to be assigned automatically.
