### PR TITLE
Update the grants page, fix about section sort order

### DIFF
--- a/content/about/code-of-conduct/contents.lr
+++ b/content/about/code-of-conduct/contents.lr
@@ -91,7 +91,7 @@ This code of conduct is largely based on the [Write The Docs Code of Conduct](ht
 ---
 show_in_menu: yes
 ---
-sort_index: 2
+sort_index: 3
 ---
 related_pages:
 

--- a/content/about/diversity-and-inclusion/contents.lr
+++ b/content/about/diversity-and-inclusion/contents.lr
@@ -43,4 +43,4 @@ We value diversity in the communities we bring together. We strive to provide ba
 
 This document borrows heavily from the diversity statements from [PyCon 2018](https://us.pycon.org/2018/about/diversity/) and [O'Reilly Media](http://assets.en.oreilly.com/1/eventprovider/1/ConfDiversity.pdf).
 ---
-sort_index: 3
+sort_index: 4

--- a/content/about/grants-faq/contents.lr
+++ b/content/about/grants-faq/contents.lr
@@ -80,6 +80,6 @@ A: The Python Software Foundation will issue disbursement of funds within 7 busi
 The maximum Grant amount for any individual is $1,500 USD. Please review your travel plans and adjust accordingly to ensure the Grant request amount to be under that amount.
 
 ---
-sort_index: 8
+sort_index: 9
 ---
 _hidden: no

--- a/content/about/grants/contents.lr
+++ b/content/about/grants/contents.lr
@@ -18,8 +18,8 @@ Note: applicants are not guaranteed the full amount that they apply for. We allo
 
 ### Timeline
 
-* November 21, 2024: Grant applications open
-* December 27, 2024: Grant applications close for all participant types
+* **November 21, 2024**: Grant applications open
+* **December 27, 2024**: Grant applications close for all participant types
 
 ### Apply
 

--- a/content/about/grants/contents.lr
+++ b/content/about/grants/contents.lr
@@ -10,19 +10,21 @@ body:
 
 Our grants program is an important tool that helps us realize a goal of creating an inclusive, respectful conference that welcomes people of all races, ethnicities, genders, ages, abilities, religions, and sexual orientations. We provide financial assistance so people who might otherwise not be able to afford to join our event can.
 
-Grants recipients for in-person tickets can have some part of their expenses (which can include travel, hotel, registration, and childcare) paid from PyCascades’s budget. Remote attendee grant recipients can have their ticket price covered and speakers can have AV needs paid for. We actively encourage people to apply for these grants. We actively encourage people to apply for these grants. Just as in previous years, we are dedicating a large portion of our budget to grants.
+Grants recipients for in-person tickets can have some part of their expenses (which can include travel, hotel, registration, etc) paid from PyCascades's budget. Remote attendee grant recipients can have their ticket price covered and speakers can have AV needs paid for. We actively encourage people to apply for these grants.
 
 Our grants program prioritizes people with relatively low income, speakers, sprint coordinators, active builders of Python community, and notable open source contributors. However, anyone who would be financially burdened by attending PyCascades is welcome to apply.
 
+Note: applicants are not guaranteed the full amount that they apply for. We allocate funds as fairly as we can across approved applicants and within the budget we are allowed.
+
 ### Timeline
 
-*   December 20th, 2022: Grant applications open
-*   February 6th, 2023: Grant applications close for all participant types
+* November 21, 2024: Grant applications open
+* December 27, 2024: Grant applications close for all participant types
 
 ### Apply
 
-If you would like to apply for a grant, please submit an application here: [https://bit.ly/PyCascades2023FinancialAidForm](https://bit.ly/PyCascades2023FinancialAidForm). If you have any questions, feel free to reach out to our financial aid team at [grants@pycascades.com](mailto:grants@pycascades.com).
+If you would like to apply for a grant, please submit an application [here](https://docs.google.com/forms/d/e/1FAIpQLSdibq_qwFce_IW6fhb6BRlixuZs82zqHBpxwRqUhPN23S7HEg/viewform). If you have any questions, feel free to reach out to our financial aid team at [grants@pycascades.com](mailto:grants@pycascades.com).
 ---
 sort_index: 8
 ---
-_hidden: yes
+_hidden: no

--- a/content/about/volunteer/contents.lr
+++ b/content/about/volunteer/contents.lr
@@ -38,6 +38,6 @@ Though we are grateful for your interest in being a volunteer, we unfortunately 
 *   **Session Chair**: Responsible for introducing speakers, ensuring speakers stay on time, and handling speaker change-over. Session chairs must be comfortable speaking in front of large crowds, no prior experience required. Expect one morning or afternoon of the conference days.
 *   **Quiet Room**: Responsible for tending the quiet room, keeping it quiet and welcoming. Expect one morning or afternoon of the conference days.
 ---
-sort_index: 4
+sort_index: 7
 ---
 _hidden: no

--- a/content/about/volunteer/contents.lr
+++ b/content/about/volunteer/contents.lr
@@ -30,7 +30,7 @@ Online volunteers will receive a free online ticket.
 
 The conference will be held at Revolution Hall in Portland, Oregon
 
-Though we are grateful for your interest in being a volunteer, we unfortunately aren't able to offer in-person volunteers a free ticket. Please [purchase your ticket](https://pretix.eu/pycascades/portland-2025/) before the event. If the ticket price is burdensome, please [apply for a grant](https://docs.google.com/forms/d/e/1FAIpQLSdibq_qwFce_IW6fhb6BRlixuZs82zqHBpxwRqUhPN23S7HEg/viewform) before Dec 27, 2024.
+Though we are grateful for your interest in being a volunteer, we unfortunately aren't able to offer in-person volunteers a free ticket. Please [purchase your ticket](https://pretix.eu/pycascades/portland-2025/) before the event. If the ticket price is burdensome, please [apply for a grant](/about/grants/) before Dec 27, 2024.
 
 *   **Venue Setup & Teardown**: Help with setting up the conference space in the morning and cleaning up the conference space in the evening. Expect about an hour of time before and/or after the talks on conference days.
 *   **Check-in & Info Desk**: Responsible for checking tickets and distributing badges, swag and lanyards to attendees. Expect one morning or afternoon of the conference days, or the first half of the pre-social (if we hold one).


### PR DESCRIPTION
Updated based on text Caito sent me.

Several pages had the same number and the ordering was wonky (eg Grants FAQ before Grants)