### PR TITLE
Add Pretalx schedule widget to website

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -47,6 +47,8 @@
 }
 
 .navbar.is-primary {
+    /* Override so the filter button on the pretalx schedule doesn't come in front of the navbar on scroll */
+    --bulma-navbar-fixed-z: 500;
     --bulma-navbar-dropdown-item-h: var(--pycascades-bright-purple-h);
     --bulma-navbar-dropdown-item-s: var(--pycascades-bright-purple-s);
     --bulma-navbar-dropdown-item-l: var(--pycascades-bright-purple-l);

--- a/content/program/schedule/contents.lr
+++ b/content/program/schedule/contents.lr
@@ -2,8 +2,25 @@ _model: page
 ---
 title: Schedule
 ---
-body: PyCascades 2025 will be February 8th and 9th in Portland OR.
+content:
 
-We're finalizing the programming, stay tuned for the schedule!
+#### html ####
+hidden: False
+----
+content:
+
+<!-- https://docs.pretalx.org/user/event/widget/ -->
+<script type="text/javascript" src="https://pretalx.com/pycascades-2025/schedule/widget/v2.en.js"></script>
+
+<pretalx-schedule event-url="https://pretalx.com/pycascades-2025/" locale="en" style="--pretalx-sticky-top-offset: var(--bulma-navbar-height)"></pretalx-schedule>
+<noscript>
+   <div class="pretalx-widget">
+        <div class="pretalx-widget-info-message">
+            JavaScript is disabled in your browser. To access our schedule without JavaScript,
+            please <a target="_blank" href="https://pretalx.com/pycascades-2025/schedule/">click here</a>.
+        </div>
+    </div>
+</noscript>
+
 ---
 show_in_menu: yes


### PR DESCRIPTION
This PR adds the Pretalx schedule widget (which we've used in previous years) to the website. We might want to take a different, more accessible route in the future, but for now this at least makes the schedule available on our primary site!

In previous years we've modified the inner HTML to link to talk pages within our own site. We can do that again this year, but starting from linking to Pretalx works for now.

This is in addition to the `add_program` branch as well, which adds the talks themselves to the site.

![image](https://github.com/user-attachments/assets/96587e6b-2548-4a92-b7be-db266029c9ab)
